### PR TITLE
Consider adding Peergrade invite link

### DIFF
--- a/assignments/Assignment1.ipynb
+++ b/assignments/Assignment1.ipynb
@@ -13,6 +13,7 @@
     "_If you fail to follow these simple instructions, it will negatively impact your grade!_\n",
     "\n",
     "**Due date and time**: The assignment is due on Monday February 27th, 2023 at 23:55. Hand in your files via [http://peergrade.io](http://peergrade.io/).\n",
+    "The Peergrade course can be accessed via [this link](https://app.peergrade.io/join/44E47G). Use your DTU email to register with Peergrade.\n",
     "\n",
     "**Peergrading date and time**: _Remember that after handing in you have 1 week to evaluate a few assignments written by other members of the class_. "
    ]


### PR DESCRIPTION
Some students may have missed the invite link message on Slack. Making it available here could possibly prevent some confusion regarding the sign-up process.